### PR TITLE
chore: remove emojis from logs and frontend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -82,7 +82,7 @@ class DuckDBManager:
                 self.connection.execute("LOAD iceberg")
                 # DuckDB 1.4+ requires explicit version handling
                 self.connection.execute("SET unsafe_enable_version_guessing=true")
-                logger.info("✓ Iceberg extension loaded")
+                logger.info("Iceberg extension loaded")
             except Exception as e:
                 logger.error(f"FATAL: Iceberg extension required but not available: {e}")
                 raise RuntimeError("Iceberg extension is required for correct data reads")
@@ -91,7 +91,7 @@ class DuckDBManager:
             self.connection.execute("SET memory_limit='2GB'")
             self.connection.execute("SET threads=4")
 
-            logger.info("✓ DuckDB initialized successfully")
+            logger.info("DuckDB initialized successfully")
 
         except Exception as e:
             logger.error(f"Failed to setup DuckDB: {e}")
@@ -153,7 +153,7 @@ class DuckDBManager:
             if config.sessionToken:
                 self.connection.execute(f"SET s3_session_token='{config.sessionToken}'")
 
-            logger.info(f"✓ Applied {config.storageType} configuration")
+            logger.info(f"Applied {config.storageType} configuration")
 
             # Attach Iceberg catalog if configured
             self._attach_iceberg_catalog(config)
@@ -191,7 +191,7 @@ class DuckDBManager:
                 )
             """)
 
-            logger.info("✓ Iceberg catalog attached")
+            logger.info("Iceberg catalog attached")
 
     def _validate_iceberg_table(self, table_path: str) -> dict:
         """
@@ -217,7 +217,7 @@ class DuckDBManager:
                     )
                 )
 
-            logger.info(f"✓ Table validation passed: {table_path}")
+            logger.info(f"Table validation passed: {table_path}")
             return {"valid": True, "warnings": []}
 
         except HTTPException:
@@ -304,7 +304,7 @@ class DuckDBManager:
                 test_query = "SELECT COUNT(*) FROM iceberg_scan('s3://movies/warehouse/demo/movies') LIMIT 1"
 
             result = self.connection.execute(test_query).fetchone()
-            logger.info(f"✓ Connection test successful: {result}")
+            logger.info(f"Connection test successful: {result}")
             return True
 
         except Exception as e:
@@ -355,7 +355,7 @@ class DuckDBManager:
             # Check if results were truncated
             truncated = len(rows) >= row_limit
 
-            logger.info(f"✓ Query completed: {len(rows)} rows in {execution_time}ms")
+            logger.info(f"Query completed: {len(rows)} rows in {execution_time}ms")
 
             return QueryResponse(
                 columns=columns,
@@ -394,9 +394,9 @@ async def lifespan(app: FastAPI):
     global db_manager
 
     # Startup
-    logger.info("🌊 Starting Cloudfloe backend...")
+    logger.info("Starting Cloudfloe backend...")
     db_manager = DuckDBManager()
-    logger.info("✓ Backend ready!")
+    logger.info("Backend ready!")
 
     yield
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,6 @@
     <header>
         <div class="header-container">
             <div class="logo">
-                <span class="logo-icon">🌊</span>
                 <span class="logo-text">Cloudfloe</span>
             </div>
             <div class="header-actions">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -112,7 +112,7 @@ class CloudfloeApp {
                 // Mock response
                 await this.sleep(1000);
                 this.currentConnection = connection;
-                statusDiv.innerHTML = '<div class="status-message status-success">✓ Connection successful</div>';
+                statusDiv.innerHTML = '<div class="status-message status-success">Connection successful</div>';
                 this.addRecentConnection(connection);
             } else {
                 const response = await fetch(`${this.backendUrl}/api/connect/test`, {
@@ -124,7 +124,7 @@ class CloudfloeApp {
                 if (response.ok) {
                     const data = await response.json();
                     this.currentConnection = connection;
-                    statusDiv.innerHTML = '<div class="status-message status-success">✓ Connection successful</div>';
+                    statusDiv.innerHTML = '<div class="status-message status-success">Connection successful</div>';
                     this.addRecentConnection(connection);
 
                     // If we got table info, show it in the editor
@@ -137,7 +137,7 @@ class CloudfloeApp {
                 }
             }
         } catch (error) {
-            statusDiv.innerHTML = `<div class="status-message status-error">✗ ${error.message}</div>`;
+            statusDiv.innerHTML = `<div class="status-message status-error">${error.message}</div>`;
         }
     }
 

--- a/scripts/upload_sample_data.py
+++ b/scripts/upload_sample_data.py
@@ -27,9 +27,9 @@ def upload_sample_data(sample_dir='sample_data', bucket_name='movies'):
     # Create bucket
     try:
         s3_client.create_bucket(Bucket=bucket_name)
-        logger.info(f"✓ Created bucket: {bucket_name}")
+        logger.info(f"Created bucket: {bucket_name}")
     except s3_client.exceptions.BucketAlreadyOwnedByYou:
-        logger.info(f"✓ Bucket {bucket_name} already exists")
+        logger.info(f"Bucket {bucket_name} already exists")
     except Exception as e:
         logger.error(f"Failed to create bucket: {e}")
         raise
@@ -40,7 +40,7 @@ def upload_sample_data(sample_dir='sample_data', bucket_name='movies'):
         logger.error(f"Sample data directory not found: {sample_dir}")
         sys.exit(1)
 
-    logger.info(f"📤 Uploading sample data from {sample_dir}...")
+    logger.info(f"Uploading sample data from {sample_dir}...")
 
     file_count = 0
     total_size = 0
@@ -56,13 +56,13 @@ def upload_sample_data(sample_dir='sample_data', bucket_name='movies'):
         file_size = file_path.stat().st_size
         total_size += file_size
         file_count += 1
-        logger.info(f"  ✓ {s3_key} ({file_size / 1024:.1f} KB)")
+        logger.info(f"  {s3_key} ({file_size / 1024:.1f} KB)")
 
-    logger.info(f"\n🎉 Upload complete!")
+    logger.info("\nUpload complete!")
     logger.info(f"  Files: {file_count}")
     logger.info(f"  Total size: {total_size / 1024 / 1024:.1f} MB")
     logger.info(f"  Bucket: s3://{bucket_name}/")
-    logger.info(f"\n✨ Ready to query!")
+    logger.info("\nReady to query!")
     logger.info(f"  MinIO Console: http://localhost:9001")
     logger.info(f"  Credentials: cloudfloe / cloudfloe123")
     logger.info(f"  Sample query: SELECT * FROM read_parquet('s3://{bucket_name}/data/**/*.parquet')")
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     try:
         upload_sample_data(sample_dir)
     except Exception as e:
-        logger.error(f"\n❌ Failed: {e}")
+        logger.error(f"\nFailed: {e}")
         import traceback
         traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
## Summary
- Strips emojis from backend log output, the sample-data uploader script, the frontend header logo, and connection-status messages
- Matches the README cleanup in c2bfd23 for a consistent, professional tone

## Files touched
- `backend/main.py` — 9 log lines
- `scripts/upload_sample_data.py` — 5 log lines
- `frontend/index.html` — header logo icon span removed
- `frontend/js/app.js` — connection-status success/error markers

## Test plan
- [ ] `docker compose up --build` starts cleanly
- [ ] Backend logs read cleanly (no mojibake or stray characters)
- [ ] Frontend header shows "Cloudfloe" text only
- [ ] Connection test success/failure messages still readable

Closes #14