### PR TITLE
chore: pin backend dependencies to tested versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
-fastapi>=0.100.0
-uvicorn[standard]>=0.23.0
-duckdb>=0.9.0
-pydantic>=2.0.0
-python-multipart
+# DuckDB >=1.4 is required for the `unsafe_enable_version_guessing` setting
+# used by the Iceberg extension.
+fastapi==0.118.0
+uvicorn[standard]==0.37.0
+duckdb==1.4.1
+pydantic==2.12.0


### PR DESCRIPTION
## Summary
- Replaces `>=` ranges in `backend/requirements.txt` with exact pins from the currently-working local venv
- Drops `python-multipart` — listed but never imported and not installed in the working environment
- Adds a comment noting DuckDB ≥1.4 is required for `unsafe_enable_version_guessing` (the Iceberg setting)

## Pinned versions
| Package | Pin |
|---|---|
| fastapi | 0.118.0 |
| uvicorn[standard] | 0.37.0 |
| duckdb | 1.4.1 |
| pydantic | 2.12.0 |

## Test plan
- [ ] `docker compose up --build` produces a working image (forces a fresh pip install with the pinned versions)
- [ ] Iceberg extension loads and `iceberg_scan()` still works on the demo MinIO dataset
- [ ] No ImportError from removed `python-multipart`

Closes #12