### PR TITLE
fix(demo): seed MinIO as an Iceberg table and use iceberg_scan

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -517,39 +517,40 @@ async def get_demo_connection():
         "accessKey": "cloudfloe",
         "secretKey": "cloudfloe123",
         "region": "us-east-1",
-        "samplePath": "s3://movies/data/**/*.parquet"
+        "tablePath": "s3://movies/warehouse/demo/movies"
     }
 
 
 @app.get("/api/demo/queries")
 async def get_demo_queries():
     """Get sample queries for demo dataset."""
+    demo_table = "s3://movies/warehouse/demo/movies"
     return {
         "queries": [
             {
                 "name": "Sample Movies",
                 "description": "Preview first 10 movies",
-                "sql": "SELECT primaryTitle, startYear, runtimeMinutes, genres FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' ORDER BY startYear DESC"
+                "sql": f"SELECT primaryTitle, startYear, runtimeMinutes, genres FROM iceberg_scan('{demo_table}') WHERE titleType = 'movie' ORDER BY startYear DESC LIMIT 10"
             },
             {
                 "name": "Row Count",
                 "description": "Count total rows in dataset",
-                "sql": "SELECT COUNT(*) as total_movies FROM read_parquet('s3://movies/data/**/*.parquet')"
+                "sql": f"SELECT COUNT(*) as total_movies FROM iceberg_scan('{demo_table}')"
             },
             {
                 "name": "Movies by Decade",
                 "description": "Count movies by decade",
-                "sql": "SELECT decade, COUNT(*) as movie_count FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' GROUP BY decade ORDER BY decade DESC"
+                "sql": f"SELECT decade, COUNT(*) as movie_count FROM iceberg_scan('{demo_table}') WHERE titleType = 'movie' GROUP BY decade ORDER BY decade DESC"
             },
             {
                 "name": "Long Movies",
                 "description": "Find movies over 3 hours",
-                "sql": "SELECT primaryTitle, startYear, runtimeMinutes FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' AND runtimeMinutes > 180 ORDER BY runtimeMinutes DESC"
+                "sql": f"SELECT primaryTitle, startYear, runtimeMinutes FROM iceberg_scan('{demo_table}') WHERE titleType = 'movie' AND runtimeMinutes > 180 ORDER BY runtimeMinutes DESC"
             },
             {
                 "name": "Popular Genres",
                 "description": "Most common genres",
-                "sql": "SELECT TRIM(genre) as genre, COUNT(*) as count FROM (SELECT UNNEST(string_split(genres, ',')) as genre FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' AND genres IS NOT NULL) GROUP BY genre ORDER BY count DESC"
+                "sql": f"SELECT TRIM(genre) as genre, COUNT(*) as count FROM (SELECT UNNEST(string_split(genres, ',')) as genre FROM iceberg_scan('{demo_table}') WHERE titleType = 'movie' AND genres IS NOT NULL) GROUP BY genre ORDER BY count DESC"
             }
         ]
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
     command: >
       bash -c "
       echo 'Installing dependencies...' &&
-      pip install --no-cache-dir boto3 &&
-      echo 'Uploading sample data to MinIO...' &&
+      pip install --no-cache-dir boto3 'pyiceberg[pyarrow,s3fs,sql-sqlite]>=0.7.0,<1.0.0' &&
+      echo 'Seeding Iceberg demo table in MinIO...' &&
       python /scripts/upload_sample_data.py /sample_data
       "
     restart: "no"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,23 +131,23 @@
             <div class="query-library">
                 <h3>Sample Queries</h3>
                 <div class="sample-queries" id="sampleQueries">
-                    <div class="query-card" data-query="SELECT primaryTitle, startYear, runtimeMinutes, genres FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' ORDER BY startYear DESC LIMIT 10">
+                    <div class="query-card" data-query="SELECT primaryTitle, startYear, runtimeMinutes, genres FROM iceberg_scan('s3://movies/warehouse/demo/movies') WHERE titleType = 'movie' ORDER BY startYear DESC LIMIT 10">
                         <div class="query-title">Sample Movies</div>
                         <div class="query-desc">Preview first 10 movies</div>
                     </div>
-                    <div class="query-card" data-query="SELECT COUNT(*) as total_movies FROM read_parquet('s3://movies/data/**/*.parquet')">
+                    <div class="query-card" data-query="SELECT COUNT(*) as total_movies FROM iceberg_scan('s3://movies/warehouse/demo/movies')">
                         <div class="query-title">Row Count</div>
                         <div class="query-desc">Count total rows in dataset</div>
                     </div>
-                    <div class="query-card" data-query="SELECT decade, COUNT(*) as movie_count, AVG(runtimeMinutes) as avg_runtime FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' AND runtimeMinutes IS NOT NULL GROUP BY decade ORDER BY decade DESC">
+                    <div class="query-card" data-query="SELECT decade, COUNT(*) as movie_count, AVG(runtimeMinutes) as avg_runtime FROM iceberg_scan('s3://movies/warehouse/demo/movies') WHERE titleType = 'movie' AND runtimeMinutes IS NOT NULL GROUP BY decade ORDER BY decade DESC">
                         <div class="query-title">Movies by Decade</div>
                         <div class="query-desc">Count movies by decade with avg runtime</div>
                     </div>
-                    <div class="query-card" data-query="SELECT primaryTitle, startYear, runtimeMinutes FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' AND runtimeMinutes > 180 ORDER BY runtimeMinutes DESC LIMIT 10">
+                    <div class="query-card" data-query="SELECT primaryTitle, startYear, runtimeMinutes FROM iceberg_scan('s3://movies/warehouse/demo/movies') WHERE titleType = 'movie' AND runtimeMinutes > 180 ORDER BY runtimeMinutes DESC LIMIT 10">
                         <div class="query-title">Long Movies</div>
                         <div class="query-desc">Find movies over 3 hours</div>
                     </div>
-                    <div class="query-card" data-query="SELECT TRIM(genre) as genre, COUNT(*) as count FROM (SELECT UNNEST(string_split(genres, ',')) as genre FROM read_parquet('s3://movies/data/**/*.parquet') WHERE titleType = 'movie' AND genres IS NOT NULL) GROUP BY genre ORDER BY count DESC LIMIT 10">
+                    <div class="query-card" data-query="SELECT TRIM(genre) as genre, COUNT(*) as count FROM (SELECT UNNEST(string_split(genres, ',')) as genre FROM iceberg_scan('s3://movies/warehouse/demo/movies') WHERE titleType = 'movie' AND genres IS NOT NULL) GROUP BY genre ORDER BY count DESC LIMIT 10">
                         <div class="query-title">Popular Genres</div>
                         <div class="query-desc">Most common movie genres</div>
                     </div>

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -1,8 +1,11 @@
 # Sample Dataset
 
-This directory contains **37,537 IMDb movies** in partitioned Parquet format.
+This directory contains **37,537 IMDb movies** as a source for the demo
+Iceberg table. The local files are Hive-partitioned Parquet; on `docker
+compose up`, the init container reads them and writes an Apache Iceberg v2
+table to MinIO at `s3://movies/warehouse/demo/movies`.
 
-## Structure
+## Source layout (local)
 
 ```
 sample_data/data/
@@ -13,38 +16,35 @@ sample_data/data/
 └── decade=2010/titleType=movie/data.parquet
 ```
 
-## Dataset Details
+## Dataset details
 
-- **Format**: Partitioned Parquet (Iceberg-compatible)
-- **Partitions**: By decade and title type (20 partitions)
-- **Total Rows**: 37,537 movies and TV shows
-- **Total Size**: ~1.8 MB compressed
+- **Target format in MinIO**: Apache Iceberg v2 (written by pyiceberg)
+- **Local source format**: Hive-partitioned Parquet (by decade / titleType)
+- **Total rows**: 37,537 movies and TV shows
+- **Source size**: ~1.8 MB compressed
 - **Source**: IMDb title.basics dataset (sample)
 
 ## Columns
 
-- `tconst` - IMDb identifier
-- `titleType` - Type of title (movie, tvSeries, etc.)
-- `primaryTitle` - Popular title
-- `originalTitle` - Original title
-- `isAdult` - Adult content flag
-- `startYear` - Release year
-- `endYear` - End year (for TV series)
-- `runtimeMinutes` - Runtime in minutes
-- `genres` - Comma-separated genres
+- `tconst` — IMDb identifier
+- `titleType` — Type of title (movie, tvSeries, etc.)
+- `primaryTitle` — Popular title
+- `originalTitle` — Original title
+- `isAdult` — Adult content flag
+- `startYear` — Release year
+- `endYear` — End year (for TV series)
+- `runtimeMinutes` — Runtime in minutes
+- `genres` — Comma-separated genres
+- `decade` — Materialised from the Hive partition
+- `titleType` — Materialised from the Hive partition
 
 ## Usage
 
-This data is automatically loaded into MinIO when you run:
-
-```bash
-docker compose up -d
-```
-
-Then query it via DuckDB:
+The demo Iceberg table is seeded automatically by `docker compose up -d`.
+Query it via DuckDB:
 
 ```sql
-SELECT * FROM read_parquet('s3://movies/data/**/*.parquet') LIMIT 100;
+SELECT * FROM iceberg_scan('s3://movies/warehouse/demo/movies') LIMIT 100;
 ```
 
 ## About This Dataset

--- a/scripts/upload_sample_data.py
+++ b/scripts/upload_sample_data.py
@@ -1,71 +1,124 @@
 #!/usr/bin/env python3
 """
-Upload pre-generated sample data to MinIO.
-"""
+Seed MinIO with the demo dataset as an Apache Iceberg table.
 
+Reads the local Hive-partitioned Parquet sample, combines it into a single
+Arrow table, and writes it as an Iceberg v2 table to
+`s3://<bucket>/warehouse/demo/movies` using pyiceberg. DuckDB's
+`iceberg_scan()` can then read the table directly, without a catalog.
+"""
+import logging
 import os
 import sys
-import boto3
 from pathlib import Path
-import logging
 
-logging.basicConfig(level=logging.INFO, format='%(message)s')
+import pyarrow.parquet as pq
+from pyiceberg.catalog.sql import SqlCatalog
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 
-def upload_sample_data(sample_dir='sample_data', bucket_name='movies'):
-    """Upload sample data directory to MinIO."""
+BUCKET = os.getenv("DEMO_BUCKET", "movies")
+WAREHOUSE = os.getenv("ICEBERG_WAREHOUSE", f"s3://{BUCKET}/warehouse")
+NAMESPACE = os.getenv("DEMO_NAMESPACE", "demo")
+TABLE_NAME = os.getenv("DEMO_TABLE", "movies")
 
-    s3_client = boto3.client(
-        's3',
-        endpoint_url=os.getenv('MINIO_ENDPOINT', 'http://minio:9000'),
-        aws_access_key_id=os.getenv('MINIO_ACCESS_KEY', 'cloudfloe'),
-        aws_secret_access_key=os.getenv('MINIO_SECRET_KEY', 'cloudfloe123'),
-        region_name='us-east-1'
+S3_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://minio:9000")
+S3_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "cloudfloe")
+S3_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "cloudfloe123")
+S3_REGION = os.getenv("MINIO_REGION", "us-east-1")
+
+
+def ensure_bucket(bucket_name: str) -> None:
+    """Create the target bucket in MinIO if it doesn't already exist."""
+    import boto3
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=S3_ENDPOINT,
+        aws_access_key_id=S3_ACCESS_KEY,
+        aws_secret_access_key=S3_SECRET_KEY,
+        region_name=S3_REGION,
     )
-
-    # Create bucket
     try:
-        s3_client.create_bucket(Bucket=bucket_name)
+        s3.create_bucket(Bucket=bucket_name)
         logger.info(f"Created bucket: {bucket_name}")
-    except s3_client.exceptions.BucketAlreadyOwnedByYou:
+    except s3.exceptions.BucketAlreadyOwnedByYou:
         logger.info(f"Bucket {bucket_name} already exists")
-    except Exception as e:
-        logger.error(f"Failed to create bucket: {e}")
-        raise
 
-    # Upload all files from sample_data directory
-    sample_path = Path(sample_dir)
-    if not sample_path.exists():
-        logger.error(f"Sample data directory not found: {sample_dir}")
+
+def load_arrow_table(sample_dir: Path):
+    """Read the Hive-partitioned Parquet dataset into a single Arrow table."""
+    data_dir = sample_dir / "data"
+    if not data_dir.exists():
+        logger.error(f"Sample data directory not found: {data_dir}")
         sys.exit(1)
 
-    logger.info(f"Uploading sample data from {sample_dir}...")
+    dataset = pq.ParquetDataset(str(data_dir))
+    arrow_table = dataset.read()
+    logger.info(
+        f"Loaded {arrow_table.num_rows} rows, {arrow_table.num_columns} columns"
+    )
+    return arrow_table
 
-    file_count = 0
-    total_size = 0
 
-    for file_path in sample_path.rglob("*.parquet"):
-        # Get relative path from sample_dir
-        relative_path = file_path.relative_to(sample_path)
-        s3_key = str(relative_path)
+def write_iceberg_table(arrow_table) -> str:
+    """Create (or replace) the Iceberg demo table and append the rows."""
+    catalog = SqlCatalog(
+        "default",
+        **{
+            "uri": "sqlite:///:memory:",
+            "warehouse": WAREHOUSE,
+            "s3.endpoint": S3_ENDPOINT,
+            "s3.access-key-id": S3_ACCESS_KEY,
+            "s3.secret-access-key": S3_SECRET_KEY,
+            "s3.region": S3_REGION,
+        },
+    )
 
-        # Upload file
-        s3_client.upload_file(str(file_path), bucket_name, s3_key)
+    existing_namespaces = {ns[0] for ns in catalog.list_namespaces()}
+    if NAMESPACE not in existing_namespaces:
+        catalog.create_namespace(NAMESPACE)
+        logger.info(f"Created namespace: {NAMESPACE}")
 
-        file_size = file_path.stat().st_size
-        total_size += file_size
-        file_count += 1
-        logger.info(f"  {s3_key} ({file_size / 1024:.1f} KB)")
+    identifier = f"{NAMESPACE}.{TABLE_NAME}"
+    table_location = f"{WAREHOUSE}/{NAMESPACE}/{TABLE_NAME}"
+
+    if catalog.table_exists(identifier):
+        logger.info(f"Dropping existing table: {identifier}")
+        catalog.drop_table(identifier)
+
+    table = catalog.create_table(
+        identifier,
+        schema=arrow_table.schema,
+        location=table_location,
+    )
+    logger.info(f"Created Iceberg table: {identifier} at {table_location}")
+
+    table.append(arrow_table)
+    logger.info(f"Appended {arrow_table.num_rows} rows")
+
+    return table_location
+
+
+def main(sample_dir: str) -> None:
+    ensure_bucket(BUCKET)
+    arrow_table = load_arrow_table(Path(sample_dir))
+    table_location = write_iceberg_table(arrow_table)
 
     logger.info("\nUpload complete!")
-    logger.info(f"  Files: {file_count}")
-    logger.info(f"  Total size: {total_size / 1024 / 1024:.1f} MB")
-    logger.info(f"  Bucket: s3://{bucket_name}/")
+    logger.info(f"  Rows: {arrow_table.num_rows}")
+    logger.info(f"  Table: {table_location}")
     logger.info("\nReady to query!")
-    logger.info(f"  MinIO Console: http://localhost:9001")
-    logger.info(f"  Credentials: cloudfloe / cloudfloe123")
-    logger.info(f"  Sample query: SELECT * FROM read_parquet('s3://{bucket_name}/data/**/*.parquet')")
+    logger.info("  MinIO Console: http://localhost:9001")
+    logger.info(f"  Credentials: {S3_ACCESS_KEY} / {S3_SECRET_KEY}")
+    logger.info(
+        f"  Sample query: SELECT * FROM iceberg_scan('{table_location}') LIMIT 10"
+    )
 
 
 if __name__ == "__main__":
@@ -73,12 +126,11 @@ if __name__ == "__main__":
         logger.error("Usage: python upload_sample_data.py <sample_data_dir>")
         sys.exit(1)
 
-    sample_dir = sys.argv[1]
-
     try:
-        upload_sample_data(sample_dir)
+        main(sys.argv[1])
     except Exception as e:
         logger.error(f"\nFailed: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
## Summary
The demo previously uploaded raw Parquet to `s3://movies/data/` and the sample queries used `read_parquet()` — which bypasses Iceberg metadata and contradicts the README. This PR makes the demo actually Iceberg-native end to end.

## What changed
- **`scripts/upload_sample_data.py`** — rewritten to use `pyiceberg` with an in-memory `SqlCatalog`. Reads the local Hive-partitioned Parquet with PyArrow, then creates (or recreates) an Iceberg v2 table at `s3://movies/warehouse/demo/movies` and appends the rows. Idempotent: the namespace/table is dropped and recreated on each run.
- **`docker-compose.yml`** — `init-data` now installs `pyiceberg[pyarrow,s3fs,sql-sqlite]` alongside `boto3`.
- **`backend/main.py`** — `/api/demo/connection` returns `tablePath` (renamed from `samplePath`) pointing at the Iceberg table. `/api/demo/queries` rewrites all five samples to use `iceberg_scan('s3://movies/warehouse/demo/movies')`.
- **`frontend/index.html`** — the five Sample Queries cards switched to `iceberg_scan()`.
- **`sample_data/README.md`** — explains the local Hive-Parquet source vs the Iceberg target in MinIO and updates the example query.

`_convert_to_iceberg_query` in `backend/main.py` is intentionally left in place as a back-compat shim for user-pasted queries.

## Verification (done)
Verified locally with `docker compose down -v && docker compose up -d --build`:
- `init-data` logs: bucket created, 37,537 rows loaded from Hive Parquet, Iceberg table written at `s3://movies/warehouse/demo/movies`
- `GET /api/demo/connection` returns the new `tablePath`
- `POST /api/query` with `SELECT COUNT(*) FROM iceberg_scan('s3://movies/warehouse/demo/movies')` → `37537` in 85 ms
- Sample-Movies query returns real rows with `titleType = 'movie'` + ORDER BY

## Test plan (reproduce)
- [ ] `docker compose down -v && docker compose up --build` — `init-data` logs end with `Upload complete!` and `Table: s3://movies/warehouse/demo/movies`
- [ ] MinIO console (http://localhost:9001, `cloudfloe` / `cloudfloe123`) shows `data/` and `metadata/` folders under `movies/warehouse/demo/movies/`
- [ ] In the Cloudfloe UI, click **Row Count** sample query — expect 37,537
- [ ] Click **Sample Movies** — expect 10 rows, most recent `startYear` first
- [ ] Click **Movies by Decade** — one row per decade

## Notes
- pyiceberg 0.11.1 was selected by the `>=0.7.0,<1.0.0` range on this run.
- Benign warnings during write: `Iceberg does not have a dictionary type. <class 'pyarrow.lib.DictionaryType'> will be inferred as int32/string on read.` DuckDB reads the table without issue.

Closes #8
