### PR TITLE
ci: add GitHub Actions workflow for lint and docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          src: "./backend ./scripts"
+          args: "check"
+
+  backend-docker:
+    name: Build backend image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: false
+          load: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  frontend-docker:
+    name: Build frontend image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: false
+          load: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,9 +8,9 @@ import logging
 import os
 import time
 from contextlib import asynccontextmanager
-from typing import Dict, List, Optional, Any
+from typing import List, Optional, Any
 
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 import uvicorn
@@ -259,7 +259,7 @@ class DuckDBManager:
         converted_sql = re.sub(parquet_pattern, replace_with_iceberg, sql, flags=re.IGNORECASE)
 
         if converted_sql != sql:
-            logger.info(f"Converted query from read_parquet to Iceberg:")
+            logger.info("Converted query from read_parquet to Iceberg:")
             logger.info(f"  Original: {sql[:100]}...")
             logger.info(f"  Converted: {converted_sql[:100]}...")
 


### PR DESCRIPTION
## Summary
Adds `.github/workflows/ci.yml` so every PR to `main` runs:

- **lint** — `ruff check` across `backend/` and `scripts/`
- **backend-docker** — builds `backend/Dockerfile` (GitHub Actions cache enabled)
- **frontend-docker** — builds `frontend/Dockerfile` (GitHub Actions cache enabled)

All three jobs run in parallel. Nothing is pushed to a registry — builds just verify the images still compose.

## Intentionally deferred
- **`ruff format --check`** — would rewrite ~half of `backend/main.py` cosmetically, and #13 (split `main.py`) is about to restructure the file anyway. Adding format enforcement there instead avoids a noisy diff that gets redone immediately.
- **`pytest`** — there are no tests yet. Arrives with #10.

## Lint fixes bundled
Ruff flagged three trivial issues, all auto-fixed:
- `backend/main.py`: remove unused `typing.Dict` import
- `backend/main.py`: remove unused `fastapi.BackgroundTasks` import
- `backend/main.py`: drop stray `f` prefix on a log line with no placeholders

## Next step (not in this PR)
Once this merges and we see the first green run, update branch protection on `main` to require the three status checks: `Lint (ruff)`, `Build backend image`, `Build frontend image`.

## Test plan
- [ ] CI runs on this PR and all three jobs go green
- [ ] `ruff check backend/ scripts/` passes locally
- [ ] `docker compose build` still works

Closes #11