### PR TITLE
docs: add CI badge and note about bundled Iceberg demo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cloudfloe
 
+[![CI](https://github.com/gordonmurray/cloudfloe/actions/workflows/ci.yml/badge.svg)](https://github.com/gordonmurray/cloudfloe/actions/workflows/ci.yml)
+
 **Query your Apache Iceberg data lake in seconds. No clusters. No ops. Just SQL.**
 
 ![Cloudfloe Screenshot](images/cloudfloe_scrrenshot.png)
@@ -62,6 +64,8 @@ docker compose up --build
 ```
 
 Wait about 30 seconds for initialization, then open **http://localhost:3000**
+
+On first start, the bundled demo seeds a 37,537-row Iceberg table at `s3://movies/warehouse/demo/movies` in the local MinIO so you can query it immediately.
 
 ### 2. Connect to Your Iceberg Table
 


### PR DESCRIPTION
## Summary
Two small README touch-ups tied to recently merged issues:

- **CI badge** at the top (#11) — links to the Actions workflow so visitors can see current build status.
- **Quick Start demo note** (#8) — one sentence explaining that the bundled stack seeds a 37,537-row Iceberg table at `s3://movies/warehouse/demo/movies` in MinIO, so users can query immediately without providing their own bucket.

## Test plan
- [ ] Badge renders on GitHub (shows current main build state)
- [ ] Quick Start still reads cleanly end to end