### PR TITLE
polish(errors): actionable delete-manifest rejection message

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -403,9 +403,13 @@ def _validate_iceberg_table(conn: duckdb.DuckDBPyConnection, table_path: str) ->
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "Table contains row-level deletes which are not supported. "
-                    "This application only supports append-only Iceberg v1/v2 tables. "
-                    "Reading this table may return incorrect data."
+                    "Table has row-level deletes (position or equality). Cloudfloe "
+                    "reads would return rows the Iceberg metadata has marked removed, "
+                    "so the query is blocked rather than silently wrong. "
+                    "Compact the table first — Spark: "
+                    "`CALL system.rewrite_data_files('<catalog>.<db>.<table>')`; "
+                    "Trino: `ALTER TABLE <table> EXECUTE optimize`; "
+                    "Iceberg CLI: `iceberg rewrite_data_files`. Then retry."
                 ),
             )
 


### PR DESCRIPTION
The previous 400 response told users *what* went wrong but not *how to fix it*:

> Table contains row-level deletes which are not supported. This application only supports append-only Iceberg v1/v2 tables. Reading this table may return incorrect data.

The fix is always the same — compact the table. Spelling it out removes a round-trip to Google / the Iceberg docs:

> Table has row-level deletes (position or equality). Cloudfloe reads would return rows the Iceberg metadata has marked removed, so the query is blocked rather than silently wrong. Compact the table first — Spark: \`CALL system.rewrite_data_files('<catalog>.<db>.<table>')\`; Trino: \`ALTER TABLE <table> EXECUTE optimize\`; Iceberg CLI: \`iceberg rewrite_data_files\`. Then retry.

## Why keep the hard block

DX.md suggested letting users proceed with a "stale data warning." Rejected — Cloudfloe's positioning (README calls out "direct Parquet reads can return deleted rows" as a danger) depends on *not* doing that. A toggle that silently re-enables wrong-row behaviour undermines the "reads Iceberg correctly" promise. Better error + hard block beats looser block + silent wrongness.

## Verified

- \`pytest\` 40 passing (ignoring \`test_metrics.py\` driving #25, unrelated).
- \`ruff check\` clean.
- One-line string change; no behaviour change beyond the message.