### PR TITLE
fix(ui): pre-fill bundled-demo MinIO defaults on storage-type change

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -76,19 +76,34 @@ class CloudfloeApp {
     updateConnectionFields(storageType) {
         const sessionTokenGroup = document.getElementById('sessionTokenGroup');
         const endpoint = document.getElementById('endpoint');
+        const accessKey = document.getElementById('accessKey');
+        const secretKey = document.getElementById('secretKey');
+        const tablePath = document.getElementById('tablePath');
+
+        // Only fill empty fields — never clobber a value the user typed.
+        const setIfEmpty = (el, value) => {
+            if (!el.value) el.value = value;
+        };
 
         switch(storageType) {
             case 's3':
                 sessionTokenGroup.style.display = 'block';
-                endpoint.placeholder = 's3://bucket/path/to/table';
+                endpoint.placeholder = 's3.amazonaws.com (leave blank for AWS default)';
                 break;
             case 'r2':
                 sessionTokenGroup.style.display = 'none';
-                endpoint.placeholder = 'https://account.r2.cloudflarestorage.com';
+                endpoint.placeholder = 'account-id.r2.cloudflarestorage.com';
                 break;
             case 'minio':
                 sessionTokenGroup.style.display = 'none';
                 endpoint.placeholder = 'http://localhost:9000';
+                // Pre-fill the bundled-demo MinIO defaults so the first-time
+                // path (pick MinIO → click Test Connection) just works.
+                // Mirrors GET /api/demo/connection.
+                setIfEmpty(endpoint, 'http://localhost:9000');
+                setIfEmpty(accessKey, 'cloudfloe');
+                setIfEmpty(secretKey, 'cloudfloe123');
+                setIfEmpty(tablePath, 's3://movies/warehouse/demo/movies');
                 break;
         }
     }


### PR DESCRIPTION
Closes #35.

## Before

Picking **MinIO** from the storage-type dropdown only updated the endpoint *placeholder*, not the field value. A first-time user who didn't notice the placeholder/value distinction left endpoint blank, the backend defaulted to \`s3.amazonaws.com\`, and AWS rejected the demo creds with 403. The "click around the bundled demo" path was a dead end.

## After

When MinIO is selected, any empty field in {endpoint, accessKey, secretKey, tablePath} is filled with the bundled-demo defaults that mirror \`GET /api/demo/connection\`:

| Field | Default |
|---|---|
| endpoint | \`http://localhost:9000\` |
| accessKey | \`cloudfloe\` |
| secretKey | \`cloudfloe123\` |
| tablePath | \`s3://movies/warehouse/demo/movies\` |

The two-line `setIfEmpty` helper guarantees we never overwrite a value the user has typed — switching to MinIO out of curiosity after typing AWS S3 creds keeps the typed creds intact.

Also fixes a pre-existing copy bug spotted along the way: the AWS S3 endpoint placeholder was \`s3://bucket/path/to/table\`, which is a *table path*, not an endpoint. Now: \`s3.amazonaws.com (leave blank for AWS default)\`.

## Verified end-to-end (headless Chrome via DevTools Protocol)

**Two-click demo path** — fresh page → pick MinIO → click Test Connection (no typing):

→ `Connection successful`. tableInfo panel: **Format iceberg-v2 | Rows 37,537 | Files 1 | Last snapshot 7m ago**. Suggested query auto-loaded into editor.

**No-clobber** — fresh page → type custom S3 endpoint/path/keys → pick MinIO from dropdown:

→ All four typed values preserved exactly as entered. The pre-fill no-ops on every field because none was empty.
